### PR TITLE
Release 6.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.2] - 2026-07-16
+
+No library code changes.
+
+### Changed
+
+- Release workflow sets `registry-url` on setup-node, matching npm's
+  official trusted publishing example.
+- Default branch is now protected by a ruleset requiring pull requests
+  with passing status checks; releases go through a PR before tagging.
+
 ## [6.0.1] - 2026-07-15
 
 No library code changes. Infrastructure and documentation release:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@borfast/arrispwgen",
-    "version": "6.0.1",
+    "version": "6.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@borfast/arrispwgen",
-            "version": "6.0.1",
+            "version": "6.0.2",
             "license": "MIT",
             "devDependencies": {
                 "@biomejs/biome": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@borfast/arrispwgen",
-    "version": "6.0.1",
+    "version": "6.0.2",
     "description": "Arris Password of the Day Generator reusable library",
     "keywords": [
         "arris",


### PR DESCRIPTION
Infrastructure-only patch release. See CHANGELOG.md for details.

Test of the new PR-based release flow: merge, then tag v6.0.2 on master to trigger the publish.