### PR TITLE
Bump @biomejs/biome to 2.5.4 (with schema + format reconciliation)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "6.0.2",
             "license": "MIT",
             "devDependencies": {
-                "@biomejs/biome": "^2.5.3",
+                "@biomejs/biome": "^2.5.4",
                 "@vitest/coverage-v8": "^4.1.10",
                 "typescript": "^7.0.2",
                 "vitest": "^4.1.10"
@@ -79,9 +79,9 @@
             }
         },
         "node_modules/@biomejs/biome": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.3.tgz",
-            "integrity": "sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==",
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.4.tgz",
+            "integrity": "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw==",
             "dev": true,
             "license": "MIT OR Apache-2.0",
             "bin": {
@@ -95,20 +95,20 @@
                 "url": "https://opencollective.com/biome"
             },
             "optionalDependencies": {
-                "@biomejs/cli-darwin-arm64": "2.5.3",
-                "@biomejs/cli-darwin-x64": "2.5.3",
-                "@biomejs/cli-linux-arm64": "2.5.3",
-                "@biomejs/cli-linux-arm64-musl": "2.5.3",
-                "@biomejs/cli-linux-x64": "2.5.3",
-                "@biomejs/cli-linux-x64-musl": "2.5.3",
-                "@biomejs/cli-win32-arm64": "2.5.3",
-                "@biomejs/cli-win32-x64": "2.5.3"
+                "@biomejs/cli-darwin-arm64": "2.5.4",
+                "@biomejs/cli-darwin-x64": "2.5.4",
+                "@biomejs/cli-linux-arm64": "2.5.4",
+                "@biomejs/cli-linux-arm64-musl": "2.5.4",
+                "@biomejs/cli-linux-x64": "2.5.4",
+                "@biomejs/cli-linux-x64-musl": "2.5.4",
+                "@biomejs/cli-win32-arm64": "2.5.4",
+                "@biomejs/cli-win32-x64": "2.5.4"
             }
         },
         "node_modules/@biomejs/cli-darwin-arm64": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.3.tgz",
-            "integrity": "sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==",
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.4.tgz",
+            "integrity": "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w==",
             "cpu": [
                 "arm64"
             ],
@@ -123,9 +123,9 @@
             }
         },
         "node_modules/@biomejs/cli-darwin-x64": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.3.tgz",
-            "integrity": "sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==",
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.4.tgz",
+            "integrity": "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ==",
             "cpu": [
                 "x64"
             ],
@@ -140,13 +140,16 @@
             }
         },
         "node_modules/@biomejs/cli-linux-arm64": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.3.tgz",
-            "integrity": "sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==",
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.4.tgz",
+            "integrity": "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -157,13 +160,16 @@
             }
         },
         "node_modules/@biomejs/cli-linux-arm64-musl": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.3.tgz",
-            "integrity": "sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==",
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.4.tgz",
+            "integrity": "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -174,13 +180,16 @@
             }
         },
         "node_modules/@biomejs/cli-linux-x64": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.3.tgz",
-            "integrity": "sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==",
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.4.tgz",
+            "integrity": "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -191,13 +200,16 @@
             }
         },
         "node_modules/@biomejs/cli-linux-x64-musl": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.3.tgz",
-            "integrity": "sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==",
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.4.tgz",
+            "integrity": "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -208,9 +220,9 @@
             }
         },
         "node_modules/@biomejs/cli-win32-arm64": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.3.tgz",
-            "integrity": "sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==",
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.4.tgz",
+            "integrity": "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w==",
             "cpu": [
                 "arm64"
             ],
@@ -225,9 +237,9 @@
             }
         },
         "node_modules/@biomejs/cli-win32-x64": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.3.tgz",
-            "integrity": "sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==",
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.4.tgz",
+            "integrity": "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q==",
             "cpu": [
                 "x64"
             ],

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "test": "vitest run"
     },
     "devDependencies": {
-        "@biomejs/biome": "^2.5.3",
+        "@biomejs/biome": "^2.5.4",
         "@vitest/coverage-v8": "^4.1.10",
         "typescript": "^7.0.2",
         "vitest": "^4.1.10"

--- a/src/arrispwgen.test.ts
+++ b/src/arrispwgen.test.ts
@@ -7,17 +7,15 @@ import {
     testDates,
 } from './helper_data.js';
 
-test.each([
-    [defaultSeedPotds],
-    [customSeedPotds, customSeed],
-])('Should generate the correct password for the given days with the given seed', (potd: string[], seed:
-    | string
-    | undefined = undefined) => {
-    testDates.forEach((date, i) => {
-        const password = a.generate(new Date(date), seed);
-        expect(password).toBe(potd[i]);
-    });
-});
+test.each([[defaultSeedPotds], [customSeedPotds, customSeed]])(
+    'Should generate the correct password for the given days with the given seed',
+    (potd: string[], seed: string | undefined = undefined) => {
+        testDates.forEach((date, i) => {
+            const password = a.generate(new Date(date), seed);
+            expect(password).toBe(potd[i]);
+        });
+    },
+);
 
 test('Should throw an exception if start date is after end date', () => {
     const fn = () => {
@@ -42,19 +40,22 @@ test.each([
     [defaultSeedPotds, 4, 6],
     [customSeedPotds, 0, 3, customSeed],
     [customSeedPotds, 4, 6, customSeed],
-])('Should generate the correct passwords for the given date interval', (potdList: string[], startIndex: number, endIndex: number, seed:
-    | string
-    | undefined = undefined) => {
-    const count = endIndex - startIndex + 1;
-    const startDate = new Date(testDates[startIndex]);
-    const endDate = new Date(testDates[endIndex]);
-    const potd = a.generate_multi(startDate, endDate, seed);
+])(
+    'Should generate the correct passwords for the given date interval',
+    (potdList: string[], startIndex: number, endIndex: number, seed:
+        | string
+        | undefined = undefined) => {
+        const count = endIndex - startIndex + 1;
+        const startDate = new Date(testDates[startIndex]);
+        const endDate = new Date(testDates[endIndex]);
+        const potd = a.generate_multi(startDate, endDate, seed);
 
-    expect(potd.length).toBe(count);
-    for (let i = startIndex; i <= endIndex; i++) {
-        const date = potd[i - startIndex].date;
-        const password = potd[i - startIndex].password;
-        expect(date).toEqual(new Date(testDates[i]));
-        expect(password).toBe(potdList[i]);
-    }
-});
+        expect(potd.length).toBe(count);
+        for (let i = startIndex; i <= endIndex; i++) {
+            const date = potd[i - startIndex].date;
+            const password = potd[i - startIndex].password;
+            expect(date).toEqual(new Date(testDates[i]));
+            expect(password).toBe(potdList[i]);
+        }
+    },
+);


### PR DESCRIPTION
Replaces Dependabot #51, which fails lint on its own. Adds the two changes Dependabot can't: biome.json schema URL → 2.5.4 and the 2.5.4 formatter pass (formatting-only test file reflow).